### PR TITLE
feat: add reading progress and copy code buttons

### DIFF
--- a/post.html
+++ b/post.html
@@ -28,6 +28,7 @@
 </head>
 
 <body>
+  <div class="progress" id="read-progress"></div>
   <a class="skip-link" href="#main">Aller au contenu</a>
   <header class="site-header">
     <nav class="nav container">

--- a/script.js
+++ b/script.js
@@ -98,7 +98,7 @@ async function loadPost(){
   const post = data.find(p => p.id === id) || data[0];
   document.title = post.title + " — Robin";
   document.getElementById('post-title').textContent = post.title;
-  document.getElementById('post-meta').textContent = `${post.date} • ${post.tags.join(', ')}`;
+  const metaEl = document.getElementById('post-meta');
   const cover = document.getElementById('post-cover');
   if(post.cover){ cover.style.backgroundImage = `url(${post.cover})`; cover.style.backgroundSize = 'cover'; cover.style.backgroundPosition = 'center'; }
   // Render markdown-lite (support basic paragraphs + code fence)
@@ -110,6 +110,31 @@ async function loadPost(){
     }
     return `<p>${block}</p>`;
   }).join('');
+
+  const plain=(post.content||'').replace(/```[\s\S]*?```/g,'');
+  const words=(plain.match(/\S+/g)||[]).length;
+  const mins=Math.max(1,Math.round(words/220));
+  if(metaEl){ metaEl.textContent=`${post.date} • ${post.tags.join(', ')} • ${mins} min`; }
+
+  document.querySelectorAll('#post-content pre').forEach(pre=>{
+    const btn=document.createElement('button');
+    btn.className='copy-btn'; btn.type='button'; btn.textContent='Copier';
+    btn.addEventListener('click',async()=>{
+      try{ await navigator.clipboard.writeText(pre.textContent); btn.textContent='Copié !'; setTimeout(()=>btn.textContent='Copier',1200);}catch(e){}
+    });
+    pre.appendChild(btn);
+  });
+
+  const progress=document.getElementById('read-progress');
+  if(progress){
+    const target=document.getElementById('post-article');
+    const onScroll=()=>{
+      const total=target.scrollHeight - window.innerHeight;
+      const scrolled=Math.min(Math.max(window.scrollY - target.offsetTop,0), total);
+      progress.style.width=(total>0?(scrolled/total)*100:0).toFixed(2)+'%';
+    };
+    window.addEventListener('scroll',onScroll,{passive:true}); onScroll();
+  }
 
   // Related
   const related = data.filter(p => p.id !== post.id && p.tags.some(t => post.tags.includes(t))).slice(0,3);

--- a/styles.css
+++ b/styles.css
@@ -89,3 +89,7 @@ img{max-width:100%; display:block}
   .contact{grid-template-columns:1fr}
   .menu{display:none}
 }
+
+.progress{position:fixed;top:0;left:0;height:3px;width:0;background:linear-gradient(90deg,var(--brand),var(--accent));z-index:1000}
+pre{position:relative}
+.copy-btn{position:absolute;top:8px;right:8px;padding:6px 10px;border-radius:10px;border:1px solid color-mix(in oklab,var(--text) 15%, transparent);background:var(--surface);cursor:pointer}


### PR DESCRIPTION
## Summary
- add fixed reading progress bar and copy buttons for code blocks
- compute article reading time and append to metadata

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e10c711c88325b12d77ae24fca929