### PR TITLE
feat: enhance blog post engagement

### DIFF
--- a/post.html
+++ b/post.html
@@ -49,6 +49,7 @@
   <div id="post-cover" class="cover"></div>
   <div id="post-content"></div>
   <hr>
+  <section id="post-cta"></section>
   <section aria-labelledby="more-like-this">
     <h2 id="more-like-this">À lire ensuite</h2>
     <div id="related" class="grid cards-grid"></div>

--- a/script.js
+++ b/script.js
@@ -68,11 +68,13 @@ async function loadPosts(){
     el.className = 'card';
     const title = highlight(p.title, q);
     const excerpt = highlight(p.excerpt, q);
+    const also = posts.find(o => o.id !== p.id && o.tags.some(t => p.tags.includes(t)));
     el.innerHTML = `
       <div class="meta">${p.date} • ${p.tags.join(', ')}</div>
       <h3><a href="post.html?id=${encodeURIComponent(p.id)}">${title}</a></h3>
       <p>${excerpt}</p>
       <a class="arrow" href="post.html?id=${encodeURIComponent(p.id)}">Lire →</a>
+      ${also ? `<div class="meta"><a href="post.html?id=${encodeURIComponent(also.id)}">${also.title}</a></div>` : ''}
     `;
     return el;
   }
@@ -112,13 +114,33 @@ async function loadPost(){
   }).join('');
 
   // Related
-  const related = data.filter(p => p.id !== post.id && p.tags.some(t => post.tags.includes(t))).slice(0,3);
+  let related = data.filter(p => p.id !== post.id && p.tags.some(t => post.tags.includes(t)));
+  if(related.length < 3){
+    const others = data.filter(p => p.id !== post.id && !related.includes(p));
+    while(related.length < 3 && others.length){
+      const r = others.splice(Math.floor(Math.random()*others.length),1)[0];
+      related.push(r);
+    }
+  }
+  related = related.slice(0,3);
   const relEl = document.getElementById('related'); relEl.innerHTML = '';
   related.forEach(p => {
     const a = document.createElement('article'); a.className='card';
     a.innerHTML = `<h3><a href="post.html?id=${encodeURIComponent(p.id)}">${p.title}</a></h3><p class="meta">${p.date} • ${p.tags.join(', ')}</p>`;
     relEl.appendChild(a);
   });
+
+  const cta=document.getElementById('post-cta');
+  if(cta){
+    cta.innerHTML=`<p>Envie de collaborer ou proposer un stage ? <a class="btn" href="contact.html">Me contacter</a></p>`;
+    const share=document.createElement('div'); share.className='share';
+    const u=encodeURIComponent(location.href), t=encodeURIComponent(post.title);
+    share.innerHTML = `
+    <a href="https://twitter.com/intent/tweet?url=${u}&text=${t}" target="_blank" rel="noopener">Partager sur X</a>
+    <a href="https://www.linkedin.com/sharing/share-offsite/?url=${u}" target="_blank" rel="noopener">Partager sur LinkedIn</a>
+  `;
+    cta.appendChild(share);
+  }
 
   function escapeHtml(s){ return s.replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;'); }
 }

--- a/styles.css
+++ b/styles.css
@@ -84,6 +84,8 @@ img{max-width:100%; display:block}
 .site-footer{margin-top:40px; border-top:1px solid color-mix(in oklab, var(--text) 15%, transparent)}
 .footer-grid{display:flex; justify-content:space-between; align-items:center; gap:12px}
 .social{display:flex; gap:12px; list-style:none; padding:0; margin:0}
+.share{display:flex;gap:10px;flex-wrap:wrap;margin-top:8px}
+.share a{padding:8px 12px;border-radius:10px;border:1px solid color-mix(in oklab,var(--text) 15%, transparent)}
 .back a{opacity:.8}
 @media (max-width: 860px){
   .contact{grid-template-columns:1fr}


### PR DESCRIPTION
## Summary
- add bottom contact CTA with share buttons
- show internal related links on listing cards
- ensure related section shows up to three posts, filling randomly if needed

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e 'const posts=require("./posts.json"); posts.forEach(post=>{ let related=posts.filter(p=>p.id!==post.id && p.tags.some(t=>post.tags.includes(t))); if(related.length<3){ const others=posts.filter(p=>p.id!==post.id && !related.includes(p)); while(related.length<3 && others.length){ const r=others.splice(Math.floor(Math.random()*others.length),1)[0]; related.push(r);} } related=related.slice(0,3); console.log(post.id, related.length); });'`


------
https://chatgpt.com/codex/tasks/task_e_689e115af69c832582d39f5c384221f8