### PR TITLE
Add 404 page and basic site directives

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,1 @@
+<!doctype html><html lang="fr"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Page introuvable — Robin</title><link rel="stylesheet" href="styles.css"></head><body><main class="container"><h1>404</h1><p>Cette page n’existe plus.</p><p><a class="btn" href="index.html">Retour à l’accueil</a></p></main></body></html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://therobfr.github.io/portfolio/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://therobfr.github.io/portfolio/index.html</loc></url>
+  <url><loc>https://therobfr.github.io/portfolio/blog.html</loc></url>
+  <url><loc>https://therobfr.github.io/portfolio/portfolio.html</loc></url>
+  <url><loc>https://therobfr.github.io/portfolio/contact.html</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- add minimal 404 page
- include robots.txt with sitemap link
- provide temporary sitemap.xml

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e1185961c832590f184e8079afddd