### PR TITLE
Improve focus states and reduced motion support

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,7 @@
   --bg: #0b1020;
   --surface: #0f172a;
   --text: #e5e7eb;
-  --muted:#94a3b8;
+  --muted:color-mix(in oklab,var(--text) 85%, transparent);
   --brand:#38bdf8;
   --accent:#22c55e;
   --ring: 0 0 0 3px rgba(56,189,248,.3);
@@ -14,7 +14,7 @@
   --bg:#f6f7fb;
   --surface:#ffffff;
   --text:#0f172a;
-  --muted:#475569;
+  --muted:color-mix(in oklab,var(--text) 80%, transparent);
   --brand:#2563eb;
   --accent:#0ea5e9;
   --shadow: 0 8px 24px rgba(2,6,23,.08);
@@ -29,10 +29,12 @@ body{
   letter-spacing:.2px; -webkit-font-smoothing:antialiased;
 }
 a{color:inherit; text-decoration:none}
+.muted{color:var(--muted)}
+:focus-visible{outline:2px solid color-mix(in oklab,var(--brand) 60%, white); outline-offset:3px}
 img{max-width:100%; display:block}
 .container{max-width:1100px; margin:auto; padding:24px}
 .skip-link{position:absolute;left:-9999px;top:auto}
-.skip-link:focus{left:16px;top:16px;background:var(--surface);padding:8px 12px;border-radius:12px;box-shadow:var(--shadow)}
+.skip-link:focus-visible{left:16px;top:16px;background:var(--surface);padding:8px 12px;border-radius:12px;box-shadow:var(--shadow)}
 .site-header{
   position:sticky;top:0;backdrop-filter:saturate(1.2) blur(10px);
   background:color-mix(in oklab, var(--bg) 85%, transparent);
@@ -44,8 +46,9 @@ img{max-width:100%; display:block}
 .logo span{opacity:.6}
 .menu{margin-left:auto;display:flex;gap:16px}
 .menu a{padding:10px 12px;border-radius:12px}
-.menu a:hover{background:color-mix(in oklab, var(--surface) 85%, transparent)}
-.theme-toggle{border:1px solid color-mix(in oklab, var(--text) 20%, transparent); background:var(--surface); color:inherit; border-radius:12px; padding:8px 10px; cursor:pointer}
+.menu a:hover,.menu a:focus-visible{background:color-mix(in oklab, var(--surface) 85%, transparent)}
+.theme-toggle{border:1px solid color-mix(in oklab, var(--text) 20%, transparent); background:var(--surface); color:inherit; border-radius:12px; padding:8px 10px; cursor:pointer; transition:transform .08s ease}
+.theme-toggle:hover,.theme-toggle:focus-visible{transform:translateY(-2px)}
 .hero{padding:56px 0 24px}
 .badge{display:inline-block; padding:6px 10px; border-radius:999px; background:color-mix(in oklab, var(--brand) 25%, transparent); color:var(--text); font-weight:600; letter-spacing:.3px}
 .hero-title{font-size:clamp(28px,6vw,56px); line-height:1.1; margin:12px 0}
@@ -53,7 +56,7 @@ img{max-width:100%; display:block}
 .hero-sub{color:var(--muted); max-width:720px}
 .cta-row{display:flex; gap:12px; margin-top:18px}
 .btn{display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:12px 16px; border-radius:14px; border:1px solid color-mix(in oklab, var(--text) 15%, transparent); background:var(--surface); box-shadow:var(--shadow); transition:transform .08s ease}
-.btn:hover{transform:translateY(-2px)}
+.btn:hover,.btn:focus-visible{transform:translateY(-2px)}
 .btn.primary{background:linear-gradient(180deg,var(--brand),color-mix(in oklab, var(--brand) 60%, black)); color:white; border:none}
 .btn.ghost{background:transparent; border-color:color-mix(in oklab, var(--brand) 35%, transparent)}
 .section-title{font-size:22px; margin:28px 0 10px}
@@ -61,7 +64,8 @@ img{max-width:100%; display:block}
 .cards-grid{grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
 .card{background:color-mix(in oklab, var(--surface) 92%, transparent); border:1px solid color-mix(in oklab, var(--text) 12%, transparent); padding:18px; border-radius:var(--radius); box-shadow:var(--shadow)}
 .card h3{margin-top:4px}
-.card .arrow{display:inline-flex; align-items:center; gap:6px; margin-top:4px}
+.card .arrow{display:inline-flex; align-items:center; gap:6px; margin-top:4px; transition:transform .08s ease}
+.card .arrow:hover,.card .arrow:focus-visible{transform:translateX(2px)}
 .center{text-align:center; margin-top:10px}
 .pillars-grid .card{min-height:120px}
 .page-head{padding:24px 0 10px}
@@ -69,7 +73,8 @@ img{max-width:100%; display:block}
 .filters{display:flex; gap:10px; align-items:center; margin:8px 0 4px}
 .filters input,.filters select{padding:10px 12px; border-radius:12px; border:1px solid color-mix(in oklab, var(--text) 15%, transparent); background:var(--surface); color:inherit}
 .tag-pills{display:flex;flex-wrap:wrap;gap:8px;margin:6px 0}
-.tag-pill{padding:6px 10px;border-radius:999px;border:1px solid color-mix(in oklab,var(--text) 15%, transparent)}
+.tag-pill{padding:6px 10px;border-radius:999px;border:1px solid color-mix(in oklab,var(--text) 15%, transparent); transition:transform .08s ease}
+.tag-pill:hover,.tag-pill:focus-visible{background:color-mix(in oklab, var(--surface) 85%, transparent); transform:translateY(-1px)}
 .tag-pill.active{background:color-mix(in oklab,var(--brand) 25%, transparent);}
 .meta{color:var(--muted); font-size:.95rem}
 .cover{aspect-ratio:16/9; border-radius:18px; background:color-mix(in oklab, var(--brand) 15%, transparent); margin:12px 0}
@@ -84,8 +89,13 @@ img{max-width:100%; display:block}
 .site-footer{margin-top:40px; border-top:1px solid color-mix(in oklab, var(--text) 15%, transparent)}
 .footer-grid{display:flex; justify-content:space-between; align-items:center; gap:12px}
 .social{display:flex; gap:12px; list-style:none; padding:0; margin:0}
-.back a{opacity:.8}
+.back a{opacity:.8; transition:opacity .08s ease}
+.back a:hover,.back a:focus-visible{opacity:1}
 @media (max-width: 860px){
   .contact{grid-template-columns:1fr}
   .menu{display:none}
+}
+
+@media (prefers-reduced-motion: reduce){
+  *{animation-duration:0.01ms !important; animation-iteration-count:1 !important; transition-duration:0.01ms !important; scroll-behavior:auto !important}
 }


### PR DESCRIPTION
## Summary
- add global :focus-visible outline for keyboard navigation
- ensure links, buttons, tag pills and card arrows have matching hover/focus states
- respect reduced motion preferences and refine muted text contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e119e89848325afe24b755a74a030