### PR TITLE
Add automated RSS and sitemap generation

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,16 @@
+name: Generate RSS and Sitemap
+on: { push: { branches: [ "main" ] } }
+permissions: { contents: write }
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - name: Generate feeds
+        env: { SITE_URL: ${{ secrets.SITE_URL }} }
+        run: node build.js
+      - name: Commit feeds
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with: { commit_message: "chore: update rss.xml & sitemap.xml" }

--- a/build.js
+++ b/build.js
@@ -1,0 +1,22 @@
+/* Génère rss.xml + sitemap.xml depuis posts.json */
+const fs=require('fs');
+const SITE_URL=process.env.SITE_URL || 'https://example.github.io/your-repo';
+const posts=JSON.parse(fs.readFileSync('posts.json','utf8'));
+const items=posts.filter(p=>p&&p.id&&p.title&&p.date).map(p=>({...p,url:`${SITE_URL}/post.html?id=${encodeURIComponent(p.id)}`}));
+const rfc=d=>new Date(d).toUTCString();
+const esc=s=>String(s).replace(/[<>&'\"]/g,c=>({'<':'&lt;','>':'&gt;','&':'&amp;',"'":'&apos;','"':'&quot;'}[c]));
+
+const rss=`<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+<title>Robin — Génétique × IA</title><link>${SITE_URL}/</link><description>Blog Génétique × IA</description>
+<lastBuildDate>${rfc(new Date())}</lastBuildDate>
+${items.map(p=>`<item><title>${esc(p.title)}</title><link>${p.url}</link><guid>${p.url}</guid><pubDate>${rfc(p.date)}</pubDate><description><![CDATA[${p.excerpt||''}]]></description></item>`).join('')}
+</channel></rss>`;
+fs.writeFileSync('rss.xml',rss.trim());
+
+const sitemap=`<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${['index.html','blog.html','portfolio.html','contact.html'].map(p=>`<url><loc>${SITE_URL}/${p}</loc></url>`).join('')}
+${items.map(p=>`<url><loc>${p.url}</loc></url>`).join('')}
+</urlset>`;
+fs.writeFileSync('sitemap.xml',sitemap.trim());


### PR DESCRIPTION
## Summary
- add Node script to generate `rss.xml` and `sitemap.xml`
- configure GitHub Actions workflow to run the script and commit the output

## Testing
- `node build.js`

------
https://chatgpt.com/codex/tasks/task_e_689e11b74a048325bdefbb737bbd6ac6