### PR TITLE
feat: add markdown content pipeline

### DIFF
--- a/.github/workflows/content-build.yml
+++ b/.github/workflows/content-build.yml
@@ -1,0 +1,14 @@
+name: Build content
+on: { push: { branches: [ "main" ] } }
+permissions: { contents: write }
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: node md2json.js
+      - run: node build-posts.js || true
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with: { commit_message: "content: regenerate posts.json & static posts" }

--- a/content/exemple.md
+++ b/content/exemple.md
@@ -1,0 +1,10 @@
+---
+id: exemple
+title: "Exemple Markdown"
+date: "2025-08-20"
+tags: ["Guide","IA"]
+excerpt: "Post écrit en Markdown."
+cover: ""
+---
+## Titre H2
+Paragraphe.

--- a/md2json.js
+++ b/md2json.js
@@ -1,0 +1,13 @@
+const fs=require('fs');const path=require('path');
+function parseFM(txt){const m=txt.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/); if(!m) return [null,txt]; const fm=Object.fromEntries(m[1].split('\n').map(l=>l.split(':').map(s=>s.trim())).map(([k,...v])=>[k, v.join(':')?.trim().replace(/^"|"$/g,'')])); return [fm,m[2]]; }
+const files=fs.readdirSync('content').filter(f=>f.endsWith('.md'));
+const posts=[];
+for(const f of files){
+  const raw=fs.readFileSync(path.join('content',f),'utf8');
+  const [fm,body]=parseFM(raw);
+  if(!fm||!fm.id||!fm.title||!fm.date){ console.error('FM manquant',f); continue; }
+  posts.push({ id:fm.id, title:fm.title, date:fm.date, tags:(fm.tags?JSON.parse(fm.tags.replace(/'/g,'"')):[]), excerpt:fm.excerpt||'', cover:fm.cover||'', content:body.trim().replace(/\r\n/g,'\n') });
+}
+posts.sort((a,b)=> new Date(b.date)-new Date(a.date));
+fs.writeFileSync('posts.json', JSON.stringify(posts,null,2));
+console.log('posts.json généré avec',posts.length,'posts');


### PR DESCRIPTION
## Summary
- add sample markdown post with front-matter
- convert markdown content into posts.json via new Node script
- build GitHub workflow to regenerate content on push

## Testing
- `node md2json.js`


------
https://chatgpt.com/codex/tasks/task_e_689e11e25754832584e7296d9c63eebb