### PR TITLE
Add PWA manifest and service worker for offline support

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Articles concis et techniques sur génétique, IA santé, et trajectoire de carrière." />
   <meta name="theme-color" content="#0f172a" />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="manifest" href="manifest.webmanifest">
   <meta property="og:title" content="Blog — Robin" />
   <meta property="og:description" content="Articles concis et techniques sur génétique, IA santé, et trajectoire de carrière." />
   <meta property="og:type" content="website" />

--- a/contact.html
+++ b/contact.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Formulaire de contact minimal et liens sociaux." />
   <meta name="theme-color" content="#0f172a" />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="manifest" href="manifest.webmanifest">
   <meta property="og:title" content="Contact — Robin" />
   <meta property="og:description" content="Formulaire de contact minimal et liens sociaux." />
   <meta property="og:type" content="website" />

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Blog & portfolio minimaliste inspiré de Framer : génétique, IA en santé, projets, réflexions." />
   <meta name="theme-color" content="#0f172a" />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="manifest" href="manifest.webmanifest">
   <meta property="og:title" content="Robin — Génétique × IA" />
   <meta property="og:description" content="Blog & portfolio minimaliste inspiré de Framer : génétique, IA en santé, projets, réflexions." />
   <meta property="og:type" content="website" />

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,11 @@
+{
+  "name":"Robin — Génétique × IA",
+  "short_name":"Robin",
+  "start_url":"index.html",
+  "display":"standalone",
+  "background_color":"#0f172a",
+  "theme_color":"#0f172a",
+  "icons":[
+    { "src":"favicon.svg", "sizes":"any", "type":"image/svg+xml" }
+  ]
+}

--- a/portfolio.html
+++ b/portfolio.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Projets, expériences, publications et CV — design inspiré Framer." />
   <meta name="theme-color" content="#0f172a" />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="manifest" href="manifest.webmanifest">
   <meta property="og:title" content="Portfolio — Robin" />
   <meta property="og:description" content="Projets, expériences, publications et CV — design inspiré Framer." />
   <meta property="og:type" content="website" />

--- a/post.html
+++ b/post.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Lecture d’un article du blog (statique, JSON)." />
   <meta name="theme-color" content="#0f172a" />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="manifest" href="manifest.webmanifest">
   <meta property="og:title" content="Article — Robin" />
   <meta property="og:description" content="Lecture d’un article du blog (statique, JSON)." />
   <meta property="og:type" content="website" />

--- a/script.js
+++ b/script.js
@@ -137,3 +137,5 @@ loadPost();
     document.head.appendChild(link);
   }, {passive:true});
 })();
+
+if('serviceWorker' in navigator){ navigator.serviceWorker.register('sw.js'); }

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,10 @@
+const CACHE='v1';
+const ASSETS=['/','/index.html','/blog.html','/post.html','/portfolio.html','/contact.html','/styles.css','/script.js','/posts.json','/favicon.svg'];
+self.addEventListener('install',e=>{ e.waitUntil(caches.open(CACHE).then(c=>c.addAll(ASSETS))); });
+self.addEventListener('activate',e=>{ e.waitUntil(caches.keys().then(keys=>Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k))))); });
+self.addEventListener('fetch',e=>{
+  const url=new URL(e.request.url);
+  if(url.origin===location.origin){
+    e.respondWith(caches.match(e.request).then(res=>res||fetch(e.request)));
+  }
+});


### PR DESCRIPTION
## Summary
- add web app manifest and link from all pages
- cache core pages and posts through a service worker
- register service worker for offline experience

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e11ca77dc8325848e6e422fa105b2